### PR TITLE
Exposed a way to set your own ordering for key/value pairs for EZFormRadioField

### DIFF
--- a/EZForm/EZForm/src/EZFormRadioField.h
+++ b/EZForm/EZForm/src/EZFormRadioField.h
@@ -95,6 +95,15 @@
  */
 - (void)setChoicesFromArray:(NSArray *)choices;
 
+/** set choices from an array of keys and values.
+ *
+ *  The order of choices is maintained
+ * 
+ *  An alternative to setChoicesFromArray: when you have a sorted list of 
+ *  keys and values.
+ */
+- (void)setChoicesFromKeys:(NSArray *)keys values:(NSArray *)values;
+
 /** Returns the keys of all choices.
  */
 - (NSArray *)choiceKeys;

--- a/EZForm/EZForm/src/EZFormRadioField.m
+++ b/EZForm/EZForm/src/EZFormRadioField.m
@@ -59,8 +59,13 @@
 
 - (void)setChoicesFromArray:(NSArray *)choices
 {
-    self.choices = [NSDictionary dictionaryWithObjects:choices forKeys:choices];
-    self.orderedKeys = choices;	    // preserve order specified by user
+    [self setChoicesFromKeys:choices values:choices];
+}
+
+- (void)setChoicesFromKeys:(NSArray *)keys values:(NSArray *)values
+{
+    _choices = [NSDictionary dictionaryWithObjects:values forKeys:keys];
+    self.orderedKeys = keys; // preserve order specified by user
 }
 
 - (void)setChoices:(NSDictionary *)newChoices


### PR DESCRIPTION
I needed to specify the ordering of the keys of an EZFormRadioField.

Previously EZFormRadioField `setChoices:` used the undefined ordering of `NSDictionary allKeys` to maintain a key order.

I exposed this method allowing me to provide my own ordering, 
