### PR TITLE
Changed tintColor on accessory view for iOS7 and up

### DIFF
--- a/EZForm/EZForm/src/EZFormStandardInputAccessoryView.m
+++ b/EZForm/EZForm/src/EZFormStandardInputAccessoryView.m
@@ -24,6 +24,8 @@
 
 #import "EZFormStandardInputAccessoryView.h"
 
+#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
+
 @interface EZFormStandardInputAccessoryView ()
 @property (nonatomic, strong) UISegmentedControl *previousNextControl;
 @end
@@ -84,6 +86,11 @@
 	UIBarButtonItem *flexibleItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
     UIBarButtonItem* doneItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Done", @"EZForm Standard Input Accessory view - Done") style:UIBarButtonItemStyleDone target:self action:@selector(doneAction:)];
 	[self setItems:@[previousNextItem, flexibleItem, doneItem]];
+
+        if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {
+            [_previousNextControl setTintColor:[UIColor whiteColor]];
+            [doneItem setTintColor:[UIColor whiteColor]];
+        }
     }
     return self;
 }


### PR DESCRIPTION
We've conditionally set the `tintColor` on the input accessory view's items.

tintColor exists on the classes in iOS6 so the code compiles under Xcode 4.6.

![screen shot 2013-09-21 at 11 31 53 pm](https://f.cloud.github.com/assets/17407/1185730/7da103f4-22c3-11e3-98b8-8288efc6a3ef.png)
