### PR TITLE
Suppress known deprecation warning until it goes away

### DIFF
--- a/EZForm/EZForm/src/EZFormStandardInputAccessoryView.m
+++ b/EZForm/EZForm/src/EZFormStandardInputAccessoryView.m
@@ -91,7 +91,10 @@
 
         if (!SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0")) {
             //this is deprecated in iOS 7
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             _previousNextControl.segmentedControlStyle = UISegmentedControlStyleBar;
+#pragma clang diagnostic pop
         }
 
         self.doneItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(doneAction:)];


### PR DESCRIPTION
I pulled in EZForm into a project I'm playing with that's iOS 7 minimum, and noticed this deprecation warning. I trust you and @jessedc know what you're doing with this, so I don't want to see the warning all the time... are you happy to suppress it for now?
