### PR TITLE
Added a setValidator method

### DIFF
--- a/EZForm/EZForm/src/EZFormField.h
+++ b/EZForm/EZForm/src/EZFormField.h
@@ -91,6 +91,20 @@ typedef BOOL (^EZFormFieldValidator)(id value);	    // block validator
  */
 - (void)setValidationFunction:(VALIDATOR)validatorFunction;
 
+/**
+ *  Sets the user-defined validator.
+ *
+ *  If there are other validators present, this function deletes
+ *  all of them and sets this validator.
+ *
+ *  For adding multiple validators look
+ *  addValidator:(BOOL (^)(id value))validator
+ *  method.
+ *
+ *  @param validator A block object containing the validation logic.
+ **/
+- (void) setValidator:(BOOL (^)(id value))validator;
+
 /** Adds a user-defined validator.
  *
  *  User-defined validators will be called, in order, to validate

--- a/EZForm/EZForm/src/EZFormField.m
+++ b/EZForm/EZForm/src/EZFormField.m
@@ -106,6 +106,12 @@
     validatorFn = validatorFunction;
 }
 
+- (void) setValidator:(BOOL (^)(id value))validator
+{
+    validationBlocks = [[NSMutableArray alloc] init];
+    [self addValidator:validator];
+}
+
 - (void)addValidator:(BOOL (^)(id value))validator
 {
     [validationBlocks addObject:[validator copy]];


### PR DESCRIPTION
When we manually add a validator to a EZFormField, we cannot change the behaviour of it. We have to re-initialize it and re-add it to the form. If we do not want to broke the order of the fields, we have to re-initialize the whole form. 

With setValidator method we can change the behaviour of an EZFormField dynamically on certain cases.