### PR TITLE
Added support for pagingEnabled scroll views for auto scroll

### DIFF
--- a/Demo/EZFormDemo/Classes/Demos/Registration Form/EZFDRegistrationFormViewController.m
+++ b/Demo/EZFormDemo/Classes/Demos/Registration Form/EZFDRegistrationFormViewController.m
@@ -183,7 +183,7 @@ static NSString * const EZFDRegistrationFormRatingKey = @"rating";
      */
     EZFormContinuousField *ratingSliderField = [[EZFormContinuousField alloc] initWithKey:EZFDRegistrationFormRatingKey];
     ratingSliderField.maximumValue = 100;
-    ratingSliderField.minimumValue = 0.0;
+    ratingSliderField.minimumValue = 0;
     [ratingSliderField setFieldValue:@50];
     [_registrationForm addFormField:ratingSliderField];
 }

--- a/EZForm/EZForm/src/EZForm.m
+++ b/EZForm/EZForm/src/EZForm.m
@@ -271,7 +271,7 @@
           CGRect convertedFrame = [formFieldView.superview convertRect:formFieldView.frame toView:self.viewToAutoScroll];
           convertedFrame = CGRectInset(convertedFrame, -self.autoScrollForKeyboardInputPaddingSize.width, -self.autoScrollForKeyboardInputPaddingSize.height); // add some padding
           if ([scrollViewToAutoScroll isPagingEnabled]) {
-            convertedFrame.origin.x = floorl(convertedFrame.origin.x / scrollViewToAutoScroll.bounds.size.width) * scrollViewToAutoScroll.bounds.size.width;
+            convertedFrame.origin.x = floorf(convertedFrame.origin.x / scrollViewToAutoScroll.bounds.size.width) * scrollViewToAutoScroll.bounds.size.width;
             convertedFrame.size.width = scrollViewToAutoScroll.bounds.size.width;
           }
           [scrollViewToAutoScroll scrollRectToVisible:convertedFrame animated:YES];

--- a/EZForm/EZForm/src/EZForm.m
+++ b/EZForm/EZForm/src/EZForm.m
@@ -271,7 +271,7 @@
           CGRect convertedFrame = [formFieldView.superview convertRect:formFieldView.frame toView:self.viewToAutoScroll];
           convertedFrame = CGRectInset(convertedFrame, -self.autoScrollForKeyboardInputPaddingSize.width, -self.autoScrollForKeyboardInputPaddingSize.height); // add some padding
           if ([scrollViewToAutoScroll isPagingEnabled]) {
-            convertedFrame.origin.x = floorf(convertedFrame.origin.x / scrollViewToAutoScroll.bounds.size.width) * scrollViewToAutoScroll.bounds.size.width;
+            convertedFrame.origin.x = floor(convertedFrame.origin.x / scrollViewToAutoScroll.bounds.size.width) * scrollViewToAutoScroll.bounds.size.width;
             convertedFrame.size.width = scrollViewToAutoScroll.bounds.size.width;
           }
           [scrollViewToAutoScroll scrollRectToVisible:convertedFrame animated:YES];

--- a/EZForm/EZForm/src/EZForm.m
+++ b/EZForm/EZForm/src/EZForm.m
@@ -260,18 +260,23 @@
         }
     }
     else if ([self.viewToAutoScroll isKindOfClass:[UIScrollView class]]) {
-	if (! CGRectIsEmpty(self.autoScrollForKeyboardInputVisibleRect)) {
-	    CGRect scrollRect = CGRectInset(self.autoScrollForKeyboardInputVisibleRect, -self.autoScrollForKeyboardInputPaddingSize.width, -self.autoScrollForKeyboardInputPaddingSize.height); // add some padding
-	    [(UIScrollView *)self.viewToAutoScroll scrollRectToVisible:scrollRect animated:YES];
-	}
-	else {
-	    UIView *formFieldView = [formField userView];
-	    if (formFieldView) {
-		CGRect convertedFrame = [formFieldView.superview convertRect:formFieldView.frame toView:self.viewToAutoScroll];
-		convertedFrame = CGRectInset(convertedFrame, -self.autoScrollForKeyboardInputPaddingSize.width, -self.autoScrollForKeyboardInputPaddingSize.height); // add some padding
-		[(UIScrollView *)self.viewToAutoScroll scrollRectToVisible:convertedFrame animated:YES];
-	    }
-	}
+      UIScrollView *scrollViewToAutoScroll = (UIScrollView *)self.viewToAutoScroll;
+      if (! CGRectIsEmpty(self.autoScrollForKeyboardInputVisibleRect)) {
+        CGRect scrollRect = CGRectInset(self.autoScrollForKeyboardInputVisibleRect, -self.autoScrollForKeyboardInputPaddingSize.width, -self.autoScrollForKeyboardInputPaddingSize.height); // add some padding
+        [scrollViewToAutoScroll scrollRectToVisible:scrollRect animated:YES];
+      }
+      else {
+        UIView *formFieldView = [formField userView];
+        if (formFieldView) {
+          CGRect convertedFrame = [formFieldView.superview convertRect:formFieldView.frame toView:self.viewToAutoScroll];
+          convertedFrame = CGRectInset(convertedFrame, -self.autoScrollForKeyboardInputPaddingSize.width, -self.autoScrollForKeyboardInputPaddingSize.height); // add some padding
+          if ([scrollViewToAutoScroll isPagingEnabled]) {
+            convertedFrame.origin.x = floorl(convertedFrame.origin.x / scrollViewToAutoScroll.bounds.size.width) * scrollViewToAutoScroll.bounds.size.width;
+            convertedFrame.size.width = scrollViewToAutoScroll.bounds.size.width;
+          }
+          [scrollViewToAutoScroll scrollRectToVisible:convertedFrame animated:YES];
+        }
+      }
     }
     else if ([self.viewToAutoScroll isKindOfClass:[UIView class]]) {
 	/* Scroll an arbitrary view by adjusting its frame enough to reveal the form field view


### PR DESCRIPTION
Using the auto scroll with a paging enabled scroll view previously would leave you half way between pages. This patch simply ensures you're scrolled to the correct origin for the page that the input field is on.
