### PR TITLE
Added Missing UITextView delegate method

### DIFF
--- a/EZForm/EZForm/src/EZFormTextField.m
+++ b/EZForm/EZForm/src/EZFormTextField.m
@@ -377,6 +377,11 @@
     [self updateValidityIndicators];
 }
 
+- (void)textViewDidEndEditing:(UITextView *)textView {
+    __strong EZForm *form = self.form;
+    [form formFieldInputDidEnd:self];
+}
+
 
 #pragma mark - EZFormField methods
 


### PR DESCRIPTION
Without this method, EZForm delegate method form: fieldDidEndEditing
doesn’t get called
