### PR TITLE
Common email validator now abides strictly to approprait RFCs

### DIFF
--- a/EZForm/EZForm/src/EZFormCommonValidators.m
+++ b/EZForm/EZForm/src/EZFormCommonValidators.m
@@ -70,46 +70,12 @@ EZFormValidateNumericInput(id input)
 BOOL
 EZFormValidateEmailFormat(NSString *value)
 {
-    /* Checks for minimum of "x@y.z"
-     * Does not allow more than one "@" character.
-     * Does not allow consecutive "." characters.
+    /* Check that value matches the
+     * RFCs 2822, 5321, 5322 and 6531
      */
-    
-    if ([value length] < 5) {
-	return NO;
-    }
-    
-    // Check for "@" char within string, but not at either end
-    NSRange range = [value rangeOfString:@"@"];
-    if (range.location == NSNotFound || range.location < 1 || range.location >= [value length]-1) {
-	return NO;
-    }
-    
-    // Check for multiple "@" chars
-    NSRange range2 = [value rangeOfString:@"@" options:NSBackwardsSearch];
-    if (range2.location != range.location) {
-	return NO;
-    }
-    
-    NSString *domain = [value componentsSeparatedByString:@"@"][1];
-    
-    if ([domain length] < 3) {
-	return NO;
-    }
-    
-    // Check for "." char within domain, but not the first character
-    range = [domain rangeOfString:@"."];
-    if (range.location == NSNotFound || range.location < 1) {
-	return NO;
-    }
-    
-    // Check for ".." char within domain
-    range = [domain rangeOfString:@".."];
-    if (range.location != NSNotFound) {
-	return NO;
-    }
-    
-    return YES;
+    NSString *emailRegex = @"[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}";
+    NSPredicate *emailPredicate = [NSPredicate predicateWithFormat:@"self MATCHES %@", emailRegex];
+    return [emailPredicate evaluateWithObject:value];
 }
 
 


### PR DESCRIPTION
The old email validator missed some important invalid emails (eg. AA@bb.123). This replacement uses a regular expression for more precise email validation.
