### PR TITLE
Update model value on UIControlEventEditingDidEnd

### DIFF
--- a/EZForm/EZForm/src/EZFormTextField.m
+++ b/EZForm/EZForm/src/EZFormTextField.m
@@ -195,7 +195,9 @@
 
 - (void)textFieldEditingDidEnd:(id)sender
 {
-#pragma unused(sender)
+    UITextField *textField = (UITextField *)sender;
+    [self setFieldValue:textField.text canUpdateView:NO];
+    [self updateValidityIndicators];
 
     __strong EZForm *form = self.form;
     [form formFieldInputDidEnd:self];


### PR DESCRIPTION
I had an issue with my email address on the realestate.com.au app. After a twitter discussion with the developers we determined it was due to my keyboard shortcut for my email address. After a bit more discussion we determined it was an issue with EZForms.

It's a slow day at work here, so here's a pull request to fix it. I just update the model value on UIControlEventEditingDidEnd.

I've never used EZForms so feel free to correct this if this isn't 100% the best way to do it.. seemed to work OK in the example app login screen though :+1: 